### PR TITLE
Nissix plugin scope-packages on test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "test",
   "version": "0.0.0",
-  "dependencies": {},
   "dependencies": {
     "proxy-middleware": "~0.5.0",
     "jshint-stylish": "~0.1.3",
@@ -53,8 +52,7 @@
     "jasmine-reporters": "^0.4.1",
     "protractor": "^1.0.0-rc4"
   },
-  "peerDependencies": {
-  },
+  "peerDependencies": {},
   "engines": {
     "node": ">=0.10.0"
   }


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 8.058s



Output Log:
Migrating package "test" in .


## Migration from non scope to @wix/scoped packages
> /tmp/cffc9488687459b4290ce2207f33c12d

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

